### PR TITLE
Strong Password for Bob User Enforcement

### DIFF
--- a/03-AdvancedPermissionsAndAccounts/04_Cross-AccountPermissions/01_DEMOSETUP/bob.yaml
+++ b/03-AdvancedPermissionsAndAccounts/04_Cross-AccountPermissions/01_DEMOSETUP/bob.yaml
@@ -5,11 +5,12 @@ Description: >
 Parameters:
   bobpassword:
     NoEcho: true
-    Description: IAM User bob Password
+    Description: IAM User bob Password.
     Type: String
     MinLength: 4
     MaxLength: 30
     AllowedPattern: ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$
+    ConstraintDescription: Password must be a minimum eight characters, at least one uppercase letter, one lowercase letter, one number and one special character.
 Resources:
   bob:
     Type: AWS::IAM::User

--- a/03-AdvancedPermissionsAndAccounts/04_Cross-AccountPermissions/01_DEMOSETUP/bob.yaml
+++ b/03-AdvancedPermissionsAndAccounts/04_Cross-AccountPermissions/01_DEMOSETUP/bob.yaml
@@ -9,7 +9,7 @@ Parameters:
     Type: String
     MinLength: 4
     MaxLength: 30
-    AllowedPattern: ^[a-zA-Z0-9]*$
+    AllowedPattern: ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$
 Resources:
   bob:
     Type: AWS::IAM::User
@@ -23,15 +23,15 @@ Resources:
         PasswordResetRequired: "false"
   policy:
     Type: AWS::IAM::ManagedPolicy
-    Properties: 
+    Properties:
       Description: Allow access to all S3 buckets and RoleAssume
       ManagedPolicyName: S3AndRoleAssume
-      PolicyDocument: 
+      PolicyDocument:
         Version: 2012-10-17
         Statement:
           - Effect: Allow
-            Action: 's3:*'
-            Resource: '*' 
+            Action: "s3:*"
+            Resource: "*"
           - Effect: Allow
-            Action: 'sts:AssumeRole'
-            Resource: '*'
+            Action: "sts:AssumeRole"
+            Resource: "*"


### PR DESCRIPTION
Updated password pattern for bob user to correspond with IAM best practice password policy and included a constraint description if the user does not meet the password policy requirements. Before it would just say "does not meet AllowedPattern: ^[a-zA-Z0-9]*$" not necessarily telling the user what the actual problem is in plain english.

Password Policy: Minimum eight characters, at least one uppercase letter, one lowercase letter, one number and one special character

Resolves #3 