### PR TITLE
Not necessary to have explicit deny DeleteUserPermissionsBoundary

### DIFF
--- a/03-AdvancedPermissionsAndAccounts/02_Boundaries/02_a4ladminboundary.json
+++ b/03-AdvancedPermissionsAndAccounts/02_Boundaries/02_a4ladminboundary.json
@@ -68,12 +68,6 @@
               "arn:aws:iam::MASTERACCOUNTNUMBER:policy/a4luserboundary",
               "arn:aws:iam::MASTERACCOUNTNUMBER:policy/a4ladminboundary"
           ]
-      },
-      {
-          "Sid": "NoBoundaryUserDelete",
-          "Effect": "Deny",
-          "Action": "iam:DeleteUserPermissionsBoundary",
-          "Resource": "*"
       }
   ]
 }


### PR DESCRIPTION
It is not necessary to have explicit deny DeleteUserPermissionsBoundary since this action will not be allowed by any other statements in this boundary.