### PR TITLE
GetBucketOwnership is needed for new S3 default settings

### DIFF
--- a/03-AdvancedPermissionsAndAccounts/04_Cross-AccountPermissions/01_DEMOSETUP/petpics2_policy.json
+++ b/03-AdvancedPermissionsAndAccounts/04_Cross-AccountPermissions/01_DEMOSETUP/petpics2_policy.json
@@ -8,6 +8,7 @@
           },
           "Action": [
               "s3:GetObject",
+              "s3:GetBucketOwnershipControls",
               "s3:PutObject",
               "s3:PutObjectAcl",
               "s3:ListBucket"


### PR DESCRIPTION
New S3 default settings do not allow ACL. If a user in different account does not have s3:GetBucketOwnershipControls, it will get "Access control list (ACL) not supported" when uploading an object.