### PR TITLE
Update Dockerfile

### DIFF
--- a/EB/EB_and_Docker/Dockerfile
+++ b/EB/EB_and_Docker/Dockerfile
@@ -1,11 +1,11 @@
-FROM ubuntu:12.04
+FROM ubuntu:14.04
 
 RUN apt-get update
 RUN apt-get install -y nginx zip curl
 
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf
-RUN curl -o /usr/share/nginx/www/master.zip -L https://codeload.github.com/gabrielecirulli/2048/zip/master
-RUN cd /usr/share/nginx/www/ && unzip master.zip && mv 2048-master/* . && rm -rf 2048-master master.zip
+RUN curl -o /usr/share/nginx/html/master.zip -L https://codeload.github.com/gabrielecirulli/2048/zip/master
+RUN cd /usr/share/nginx/html/ && unzip master.zip && mv 2048-master/* . && rm -rf 2048-master master.zip
 
 EXPOSE 80
 


### PR DESCRIPTION
12.04 is a bit too old to have apt-get run normally.
Update base image from ubuntu 12.04 to 14.04
nginx path changed from /usr/share/nginx/www to /usr/share/nginx/html