### PR TITLE
Update 02_a4ladminboundary.json

### DIFF
--- a/03-AdvancedPermissionsAndAccounts/02_Boundaries/02_a4ladminboundary.json
+++ b/03-AdvancedPermissionsAndAccounts/02_Boundaries/02_a4ladminboundary.json
@@ -53,7 +53,7 @@
               "iam:SimulatePrincipalPolicy",
               "iam:SimulateCustomPolicy" 
           ],
-          "NotResource": "arn:aws:iam::MASTERACCOUNTNUMBER:user/bob"
+          "NotResource": "arn:aws:iam::MASTERACCOUNTNUMBER:user/${aws:username}"
       },
       {
           "Sid": "NoBoundaryPolicyEdit",


### PR DESCRIPTION
Use AWS parameter in reference to username
Make the policy conceptually in line with other example policies.
This change makes the policy generic. Using a literal username makes the policy user specific which is not recommended.