### PR TITLE
Update prod_bucketsandrole.yaml

### DIFF
--- a/03-AdvancedPermissionsAndAccounts/04_Cross-AccountPermissions/01_DEMOSETUP/prod_bucketsandrole.yaml
+++ b/03-AdvancedPermissionsAndAccounts/04_Cross-AccountPermissions/01_DEMOSETUP/prod_bucketsandrole.yaml
@@ -9,6 +9,10 @@ Parameters:
 Resources:
   petpics1:
     Type:  AWS::S3::Bucket
+    Properties:
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: ObjectWriter
   petpics2:
     Type:  AWS::S3::Bucket
   petpics3:


### PR DESCRIPTION
Add ObjectOwnership rule to enable ACLs. See [this post](https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/) for more details.

Without this change, the video's instructions are not possible. When I go into the `petpics1` bucket's permissions, I am unable to edit the ACL.

With this change, I am now able to edit the ACL.