### PR TITLE
Update petpics2_policy.json

### DIFF
--- a/03-AdvancedPermissionsAndAccounts/04_Cross-AccountPermissions/01_DEMOSETUP/petpics2_policy.json
+++ b/03-AdvancedPermissionsAndAccounts/04_Cross-AccountPermissions/01_DEMOSETUP/petpics2_policy.json
@@ -10,7 +10,8 @@
               "s3:GetObject",
               "s3:PutObject",
               "s3:PutObjectAcl",
-              "s3:ListBucket"
+              "s3:ListBucket",
+              "s3:GetBucketOwnershipControls"
           ],
           "Resource": [
               "arn:aws:s3:::REPLACEME_BUCKETNAME/*",


### PR DESCRIPTION
The policy needs to allow the bucket to see the ownership controls or else the upload will fail. See [this forum post](https://repost.aws/questions/QU5KfnbV5FQi6AYgDDhNcaFg/s3-upload-issues-through-the-aws-console#ANgntEg3GuQrmOt276IKlY1A) for more context.