### PR TITLE
Fix issue where AWS Console is not permitting upload

### DIFF
--- a/03-AdvancedPermissionsAndAccounts/04_Cross-AccountPermissions/01_DEMOSETUP/petpics2_policy.json
+++ b/03-AdvancedPermissionsAndAccounts/04_Cross-AccountPermissions/01_DEMOSETUP/petpics2_policy.json
@@ -9,7 +9,7 @@
           "Action": [
               "s3:GetObject",
               "s3:PutObject",
-              "s3:PutObjectAcl",
+              "s3:GetBucketOwnershipControls",
               "s3:ListBucket"
           ],
           "Resource": [


### PR DESCRIPTION
I was experiencing the issue described here: https://repost.aws/questions/QU5KfnbV5FQi6AYgDDhNcaFg/s3-upload-issues-through-the-aws-console

"when using the AWS console, user B gets an error "Access control list (ACL) not supported", but I can still upload files when using the aws cli."

Apparently, you need "s3:GetBucketOwnershipControls" (now) in order to upload successfully from the Console.